### PR TITLE
Fix broken `Ren'Py` installer

### DIFF
--- a/renpy/tools/chocolateyinstall.ps1
+++ b/renpy/tools/chocolateyinstall.ps1
@@ -1,4 +1,4 @@
-$ErrorActionPreference = 'Stop';
+﻿$ErrorActionPreference = 'Stop';
 $toolsPath = Split-Path $MyInvocation.MyCommand.Definition;
 
 $archiveArgs = @{
@@ -9,8 +9,12 @@ $archiveArgs = @{
   unzipLocation = $toolsPath
 }
 
+# The renpy installer is a `7z`-package wrapped in a self extracting archive.
+# Cause of the architecture of such an sfx archive, these files safely can be unzipped using 7-zip
 Install-ChocolateyZipPackage @archiveArgs
 
+# ShimGen will add an executable file to `PATH` for each `.exe`-file in this package.
+# This step ensures that all unnecessary executables are ignored by adding a `{ExeFileName}.ignore` file.
 $exeFiles = Get-ChildItem $toolsPath -Recurse -Filter *.exe
 
 $entryPoints = @(

--- a/renpy/tools/chocolateyinstall.ps1
+++ b/renpy/tools/chocolateyinstall.ps1
@@ -1,15 +1,12 @@
-﻿$ErrorActionPreference = 'Stop';
+$ErrorActionPreference = 'Stop';
 $toolsPath = Split-Path $MyInvocation.MyCommand.Definition;
 
-$packageArgs = @{
+$archiveArgs = @{
   packageName   = 'renpy'
-  fileType      = 'exe'
   url           = 'https://www.renpy.org/dl/7.3.5/renpy-7.3.5-sdk.7z.exe'
-  softwareName  = 'renpy*'
   checksum      = '3f2760be6c8b36698308470947783b1f5ce7ebcb4e2ae6bf2761212f5c925823'
   checksumType  = 'sha256'
-  silentArgs    = "-y -gm2 -o$toolsPath"
-  validExitCodes= @(0)
+  unzipLocation = $toolsPath
 }
 
-Install-ChocolateyPackage @packageArgs
+Install-ChocolateyZipPackage @archiveArgs

--- a/renpy/tools/chocolateyinstall.ps1
+++ b/renpy/tools/chocolateyinstall.ps1
@@ -1,4 +1,5 @@
 ﻿$ErrorActionPreference = 'Stop';
+$toolsPath = Split-Path $MyInvocation.MyCommand.Definition;
 
 $packageArgs = @{
   packageName   = 'renpy'
@@ -7,7 +8,7 @@ $packageArgs = @{
   softwareName  = 'renpy*'
   checksum      = '3f2760be6c8b36698308470947783b1f5ce7ebcb4e2ae6bf2761212f5c925823'
   checksumType  = 'sha256'
-  silentArgs    = "-y -gm2"
+  silentArgs    = "-y -gm2 -o$toolsPath"
   validExitCodes= @(0)
 }
 

--- a/renpy/tools/chocolateyinstall.ps1
+++ b/renpy/tools/chocolateyinstall.ps1
@@ -10,3 +10,14 @@ $archiveArgs = @{
 }
 
 Install-ChocolateyZipPackage @archiveArgs
+
+$exeFiles = Get-ChildItem $toolsPath -Recurse -Filter *.exe
+
+$entryPoints = @(
+  $(Get-ChildItem $(Join-Path $toolsPath "renpy*/renpy.exe")).FullName);
+
+foreach ($exeFile in $exeFiles) {
+  if (-not $entryPoints.Contains($exeFile.FullName)) {
+    New-Item -ItemType File "$($exeFile.FullName).ignore"
+  }
+}


### PR DESCRIPTION
Currently the `Ren'Py` installer is not working correctly.
The contents of the renpy-installer are being extracted to the `%TEMP%` directory and, therefore, `renpy.exe` is not being added to `PATH`.

This PR fixes both said issues and I really hope you'll publish the package after merging this PR.

## Silent Installation
First thing I have noticed is, that `renpy` is not being installed silently (even though, `-gm2 -y` is passed).
That's probably because the SFX archive provided by renpy was not created using 7-zip but some other kind of tool.

Luckily, due to the structure of self-extracting archives, this file can safely be extracted using `7z.exe` (or `Install-ChocolateyZipPackage`).
Have a look at 53d3a6a to see the changes.

## Incorrect Installation Path
Currently `renpy` is being installed to the temp-directory `%TEMP%` instead of the actual location of your renpy-package.
This PR also solves this issue according to the code-examples provided by chocolatey themselves.
Have a look at 31acddf to see the changes I've made.

## Add Correct Shims
After installing a package, chocolatey adds all `.exe`-files inside the package to `PATH`.
As we only want `renpy.exe` to end up in `PATH` I had to make sure all other exe-files are being ignored.

See 7c982c7 for more info

# Final words
Thank you very much for maintaining the `renpy` choco-package, you're doing an awesome job!
Though, I'd really recommend you to enable the `Issues` functionality for this repository so that people can report errors when using one of your packages.

That way you'll always be able to improve your code ✨