### PR TITLE
Update Ren'Py and add Startmenu-Shortcut

### DIFF
--- a/renpy/renpy.nuspec
+++ b/renpy/renpy.nuspec
@@ -3,7 +3,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>renpy</id>
-    <version>7.3.5.1</version>
+    <version>7.4.0</version>
     <title>Ren'Py (Install)</title>
     <owners>William Darian</owners>
     <authors>Tom "PyTom" Rothamel, Andy_kl, Arda Güler, DragoonHP, Jan Beich, Kobaltcore, Lee Yunseok, Mal Graty, Moshibit, Nyaatrap, Pionere, Sylvain Beucler</authors>

--- a/renpy/tools/chocolateyUninstall.ps1
+++ b/renpy/tools/chocolateyUninstall.ps1
@@ -1,0 +1,1 @@
+Remove-Item $(Join-Path -Path $([System.Environment]::GetFolderPath("CommonStartMenu")) -ChildPath $([string]::Join([System.IO.Path]::DirectorySeparatorChar, @("Programs", "Ren'Py.lnk"))))

--- a/renpy/tools/chocolateyinstall.ps1
+++ b/renpy/tools/chocolateyinstall.ps1
@@ -21,7 +21,11 @@ $entryPoints = @(
   $(Get-ChildItem $(Join-Path $toolsPath "renpy*/renpy.exe")).FullName);
 
 foreach ($exeFile in $exeFiles) {
-  if (-not $entryPoints.Contains($exeFile.FullName)) {
-    New-Item -ItemType File "$($exeFile.FullName).ignore";
+  $ignoreFileName = "$($exeFile.FullName).ignore";
+
+  if (
+    -not $entryPoints.Contains($exeFile.FullName) -and
+    -not $(Test-Path $ignoreFileName)) {
+      New-Item -ItemType File $ignoreFileName;
   }
 }

--- a/renpy/tools/chocolateyinstall.ps1
+++ b/renpy/tools/chocolateyinstall.ps1
@@ -17,8 +17,10 @@ Install-ChocolateyZipPackage @archiveArgs;
 # This step ensures that all unnecessary executables are ignored by adding a `{ExeFileName}.ignore` file.
 $exeFiles = Get-ChildItem $toolsPath -Recurse -Filter *.exe;
 
+$mainEntryPoint = $(Get-ChildItem $(Join-Path $toolsPath "renpy*/renpy.exe")).FullName;
+
 $entryPoints = @(
-  $(Get-ChildItem $(Join-Path $toolsPath "renpy*/renpy.exe")).FullName);
+  $mainEntryPoint);
 
 foreach ($exeFile in $exeFiles) {
   $ignoreFileName = "$($exeFile.FullName).ignore";
@@ -29,3 +31,7 @@ foreach ($exeFile in $exeFiles) {
       New-Item -ItemType File $ignoreFileName;
   }
 }
+
+Install-ChocolateyShortcut `
+  -ShortcutFilePath $(Join-Path -Path $([System.Environment]::GetFolderPath("CommonStartMenu")) -ChildPath $([string]::Join([System.IO.Path]::DirectorySeparatorChar, @("Programs", "Ren'Py.lnk")))) `
+  -TargetPath $mainEntryPoint;

--- a/renpy/tools/chocolateyinstall.ps1
+++ b/renpy/tools/chocolateyinstall.ps1
@@ -1,4 +1,4 @@
-﻿$ErrorActionPreference = 'Stop';
+$ErrorActionPreference = 'Stop';
 $toolsPath = Split-Path $MyInvocation.MyCommand.Definition;
 
 $archiveArgs = @{
@@ -7,21 +7,21 @@ $archiveArgs = @{
   checksum      = '3f2760be6c8b36698308470947783b1f5ce7ebcb4e2ae6bf2761212f5c925823'
   checksumType  = 'sha256'
   unzipLocation = $toolsPath
-}
+};
 
 # The renpy installer is a `7z`-package wrapped in a self extracting archive.
 # Cause of the architecture of such an sfx archive, these files safely can be unzipped using 7-zip
-Install-ChocolateyZipPackage @archiveArgs
+Install-ChocolateyZipPackage @archiveArgs;
 
 # ShimGen will add an executable file to `PATH` for each `.exe`-file in this package.
 # This step ensures that all unnecessary executables are ignored by adding a `{ExeFileName}.ignore` file.
-$exeFiles = Get-ChildItem $toolsPath -Recurse -Filter *.exe
+$exeFiles = Get-ChildItem $toolsPath -Recurse -Filter *.exe;
 
 $entryPoints = @(
   $(Get-ChildItem $(Join-Path $toolsPath "renpy*/renpy.exe")).FullName);
 
 foreach ($exeFile in $exeFiles) {
   if (-not $entryPoints.Contains($exeFile.FullName)) {
-    New-Item -ItemType File "$($exeFile.FullName).ignore"
+    New-Item -ItemType File "$($exeFile.FullName).ignore";
   }
 }

--- a/renpy/tools/chocolateyinstall.ps1
+++ b/renpy/tools/chocolateyinstall.ps1
@@ -1,10 +1,10 @@
-$ErrorActionPreference = 'Stop';
+﻿$ErrorActionPreference = 'Stop';
 $toolsPath = Split-Path $MyInvocation.MyCommand.Definition;
 
 $archiveArgs = @{
   packageName   = 'renpy'
-  url           = 'https://www.renpy.org/dl/7.3.5/renpy-7.3.5-sdk.7z.exe'
-  checksum      = '3f2760be6c8b36698308470947783b1f5ce7ebcb4e2ae6bf2761212f5c925823'
+  url           = 'https://www.renpy.org/dl/7.4.0/renpy-7.4.0-sdk.7z.exe'
+  checksum      = '6693256c21f6f7d277b1fc7d1ed24fa3170cfdf1d2371d1235b87e801fddcbd2'
   checksumType  = 'sha256'
   unzipLocation = $toolsPath
 };


### PR DESCRIPTION
Merging this PR will add the functionality to add a startmenu shortcut creation on installation and removal on uninstallation.
Additionally I bumped Ren'Py to the most recent version (7.4.0).